### PR TITLE
Add 'alt' to bidix E and monodix pardef . Fixes #8 . Fixes #1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+build/
+dist/
+target/
+

--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -38,8 +38,8 @@ javac.compilerargs=
 javac.deprecation=false
 javac.processorpath=\
     ${javac.classpath}
-javac.source=1.7
-javac.target=1.7
+javac.source=1.8
+javac.target=1.8
 javac.test.classpath=\
     ${javac.classpath}:\
     ${build.classes.dir}:\

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
 					<source>1.8</source>
-					<target>1.7</target>
+					<target>1.8</target>
 					<encoding>${project.build.sourceEncoding}</encoding>
 				</configuration>
 			</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.7</source>
+					<source>1.8</source>
 					<target>1.7</target>
 					<encoding>${project.build.sourceEncoding}</encoding>
 				</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -74,8 +74,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.7</source>
+					<target>1.7</target>
 					<encoding>${project.build.sourceEncoding}</encoding>
 				</configuration>
 			</plugin>
@@ -115,6 +115,11 @@
 	</build>
 	
 	<dependencies>
+		<dependency>
+			<groupId>xerces</groupId>
+			<artifactId>xercesImpl</artifactId>
+			<version>2.12.2</version>
+		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>

--- a/src/dics/elements/dtd/E.java
+++ b/src/dics/elements/dtd/E.java
@@ -616,6 +616,7 @@ public class E extends DixElement implements Cloneable {
     public String toString() {
         StringBuilder str = new StringBuilder(50);
         str.append("<e");
+        appendXmlAttr(str, "alt", alt);
         appendXmlAttr(str, "i", ignore);
         appendXmlAttr(str, "r", restriction);
 

--- a/src/dics/elements/dtd/Pardef.java
+++ b/src/dics/elements/dtd/Pardef.java
@@ -39,6 +39,8 @@ public class Pardef extends DixElement {
 
     public String comment;
 
+    public String alt;
+
     /** Line number from source file */
     public int lineNo;
 

--- a/src/dictools/DicFix.java
+++ b/src/dictools/DicFix.java
@@ -155,6 +155,12 @@ public class DicFix extends AbstractDictTool {
 
         StringBuilder str = new StringBuilder(50);
 
+        if (e.alt != null) {
+            str.append("<alt alt=\"");
+            str.append(e.alt);
+            str.append("\" />");
+        }
+
         if (hackyRemoval) {
           str.append(e.lemma);
           if (e.comment != null) continue;

--- a/src/dictools/guessparadigm/suffixtree/SuffixTree.java
+++ b/src/dictools/guessparadigm/suffixtree/SuffixTree.java
@@ -33,7 +33,7 @@ public class SuffixTree implements Serializable{
     static public Character GetCharObject(char character){
         Character c=chars.get(character);
         if(c==null){
-            c=new Character(character);
+            c= character;
             chars.put(c,c);
             return c;
         }

--- a/src/dictools/utils/DictionaryReader.java
+++ b/src/dictools/utils/DictionaryReader.java
@@ -289,6 +289,7 @@ public class DictionaryReader extends XMLReader {
         String n = getAttributeValue(e, "n");
         Pardef pardefElement = new Pardef(n);
         pardefElement.comment = getAttributeValue(e, "c");
+        pardefElement.alt = getAttributeValue(e, "alt");
         pardefElement.lineNo = getLineNo(e);
 
 

--- a/src/dictools/utils/KeepTrackOfLocationDOMParser.java
+++ b/src/dictools/utils/KeepTrackOfLocationDOMParser.java
@@ -5,13 +5,12 @@
 
 package dictools.utils;
 
-
-import com.sun.org.apache.xerces.internal.parsers.DOMParser;
-import com.sun.org.apache.xerces.internal.xni.Augmentations;
-import com.sun.org.apache.xerces.internal.xni.NamespaceContext;
-import com.sun.org.apache.xerces.internal.xni.QName;
-import com.sun.org.apache.xerces.internal.xni.XMLAttributes;
-import com.sun.org.apache.xerces.internal.xni.XMLLocator;
+import org.apache.xerces.parsers.DOMParser;
+import org.apache.xerces.xni.Augmentations;
+import org.apache.xerces.xni.NamespaceContext;
+import org.apache.xerces.xni.QName;
+import org.apache.xerces.xni.XMLAttributes;
+import org.apache.xerces.xni.XMLLocator;
 import dics.elements.dtd.Dictionary;
 import dics.elements.dtd.E;
 import dics.elements.dtd.Section;


### PR DESCRIPTION
This MR adds `alt` to `E` and to `pardef`.

It also updates java version (I was not able to make it work with the previous one, openjdk21 cannot build java6 anymore). And to do that, I had to change the library used for XML parsing.